### PR TITLE
Fix PHP 7.1-v1 image

### DIFF
--- a/7.1-v1/Dockerfile
+++ b/7.1-v1/Dockerfile
@@ -30,4 +30,4 @@ RUN docker-php-ext-configure intl \
         zip
 
 # Install composer from the composer base image
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
- fix 7.1-v1 image to use composer v1 since composer v2 is no longer enabled on PHP 7.1 & below